### PR TITLE
MQ queue manager creation

### DIFF
--- a/resources/ansible/mq-automation/group_vars/all/main.yml
+++ b/resources/ansible/mq-automation/group_vars/all/main.yml
@@ -1,12 +1,30 @@
 ---
 # vars file for mq-testing
 MQM_BIN_PATH: "/opt/mqm/bin"
-queuemgr: "DRHAQM1"
+queuemgrs: 
+  - name: "HAQM1"
+    is_dr: false
+    is_ha: true
+    size: "1024M"
+  - name: "HAQM2"
+    is_dr: false
+    is_ha: true
+    size: "1024M"
+  - name: "HAQM3"
+    is_dr: false
+    is_ha: true
+    size: "2048M"
 enable_rdqm: true
+
+mqm_uid: 1001
+mqm_gid: 1001
 
 version: 9.3.2
 os: rhel 
 rel: el8
+
+mq_storage_dev: vdb
+rdqm_storage_dev: vdc
 
 # Some env vars here
 

--- a/resources/ansible/mq-automation/inventory.ini.default
+++ b/resources/ansible/mq-automation/inventory.ini.default
@@ -1,24 +1,24 @@
 [mqipt_hosts]
 mqipt ansible_host=<MQIPTIP> ansible_user=root
 
-[washington]
+[primary]
 wdc1-mq1.fqdn.com ansible_host=a.b.c.d backend_ip=c.d.e.f mq_role=primary
 wdc2-mq1.fqdn.com ansible_host=a.b.c.e backend_ip=c.d.e.g mq_role=standby
 wdc3-mq1.fqdn.com ansible_host=a.b.c.f backend_ip=c.d.e.h mq_role=standby
 
-[dallas]
+[dr]
 dal1-mq1.fqdn.com ansible_host=a.b.d.e backend_ip=c.d.e.g mq_role=primary
 dal2-mq1.fqdn.com ansible_host=a.b.d.f backend_ip=c.d.e.h mq_role=standby
 dal3-mq1.fqdn.com ansible_host=a.b.d.g backend_ip=c.d.e.j mq_role=standby
 
-[washington:vars]
+[primary:vars]
 ansible_port=22
 ansible_user=root
 private_key_file=keys/keyfile
 #load_balancer="<LOADBALANCERWASHINGTON>"
 #ansible_ssh_common_args='-l root -i keys/keyfile -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand="ssh -l root -i keys/keyfile -W %h:%p -q <BASTIONIP>"'
 
-[dallas:vars]
+[dr:vars]
 ansible_port=22
 ansible_user=root
 private_key_file=keys/keyfile

--- a/resources/ansible/mq-automation/playbook.yaml.default
+++ b/resources/ansible/mq-automation/playbook.yaml.default
@@ -1,4 +1,4 @@
-- hosts: primary
+- hosts: primary,dr 
   become: true
   become_user: root
   gather_facts: true

--- a/resources/ansible/mq-automation/roles/mq-install/defaults/main.yml
+++ b/resources/ansible/mq-automation/roles/mq-install/defaults/main.yml
@@ -1,8 +1,3 @@
 ---
-# defaults file for mq-automation
-#version: 9.3.2
-#os: linux 
+# defaults file for mq-install role
 mq_dl_url: "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv"
-
-mq_storage_dev: /dev/vdb
-rdqm_storage_dev: /dev/vdc

--- a/resources/ansible/mq-automation/roles/mq-install/tasks/main.yml
+++ b/resources/ansible/mq-automation/roles/mq-install/tasks/main.yml
@@ -20,3 +20,7 @@
   import_tasks: mq-install.yaml
   tags: install, defaults
 
+- name: Create Queue Managerts
+  import_tasks: mq-create-qm.yaml
+  tags: createqm, defaults
+

--- a/resources/ansible/mq-automation/roles/mq-install/tasks/mq-create-qm.yaml
+++ b/resources/ansible/mq-automation/roles/mq-install/tasks/mq-create-qm.yaml
@@ -1,0 +1,20 @@
+- name: Get a list of existing Queue Managers
+  shell: "/opt/mqm/bin/dspmq | awk '{print $1}' | sed 's/^QMNAME(//' | sed 's/)//'"
+  register: qmgrlist
+
+- name: Create Queue Managers
+  block:
+  - name: Create HA queue manager on standby nodes
+    shell: "sudo /opt/mqm/bin/crtmqm -sxs -fs {{ item.size }} {{ item.name }}"
+    loop: "{{ queuemgrs }}"
+    become_user: "mqm"
+    when: 
+      - "'standby' in mq_role and item.is_ha|bool and not item.is_dr|bool and item.name not in qmgrlist.stdout_lines"
+
+  - name: Create HA queue manager on primary nodes
+    shell: "sudo /opt/mqm/bin/crtmqm -sx -fs {{ item.size }} {{ item.name }}"
+    loop: "{{ queuemgrs }}"
+    become_user: "mqm"
+    when: 
+      - "'primary' in mq_role and item.is_ha|bool and not item.is_dr|bool and item.name not in qmgrlist.stdout_lines"
+  when: "enable_rdqm|bool"

--- a/resources/ansible/mq-automation/roles/mq-install/tasks/mq-create-users.yaml
+++ b/resources/ansible/mq-automation/roles/mq-install/tasks/mq-create-users.yaml
@@ -4,13 +4,13 @@
     ansible.builtin.group:
       name: "mqm"
       state: present
-      gid: 1001
+      gid: "{{ mqm_gid }}"
 
   - name: Create the user for mqm
     ansible.builtin.user:
       name: "mqm"
       comment: MQM User
-      uid: 1001
+      uid: "{{ mqm_uid }}"
       group: "mqm"
 
   - name: Set up MQ user's env vars

--- a/resources/ansible/mq-automation/roles/mq-install/tasks/mq-filesystems.yaml
+++ b/resources/ansible/mq-automation/roles/mq-install/tasks/mq-filesystems.yaml
@@ -1,32 +1,41 @@
-- name: Collect any existing VGs since the lvol module isn't idempotent 
-  shell: vgs --noheadings | egrep "MQStorageVG|drbdpool" | awk '{print $1}'
-  register: vgsout
-
 - name: Configure MQ Storage Device
   block:
   - name: Create MQStorageVG
     community.general.lvg:
       vg: MQStorageVG
-      pvs: "{{ mq_storage_dev }}"
+      pvs: "/dev/{{ mq_storage_dev }}"
+    failed_when: "mq_storage_dev not in ansible_facts.devices.keys()|list"
 
   - name: Create the LV for MQ Storage
     community.general.lvol:
       vg: MQStorageVG
       lv: MQStorageLV
       size: 100%FREE
-  when: "'MQStorageVG' not in vgsout.stdout_lines"
+  when: "'MQStorageVG' not in ansible_facts.lvm.vgs.keys()|list"
+
+- set_fact:
+    part_name: "{{ rdqm_storage_dev }}1"
+
+- debug:
+    msg: "{{ part_name }}"
 
 - name: Create the DRBD Pool storage
   block:
+  - name: Reset the fact for our primary partition in case we got NVME ssd 
+    set_fact:
+      part_name: "{{ rdqm_storage_dev }}p1"
+    when: "'nvme' in rdqm_storage_dev"
+
   - name: Part up the Device
     community.general.parted:
-      device: "{{ rdqm_storage_dev }}"
+      device: "/dev/{{ rdqm_storage_dev }}"
       number: 1
       state: present
       fs_type: ext4
+    failed_when: "rdqm_storage_dev not in ansible_facts.devices.keys()|list"
 
   - name: Configure the DRBD pool storage device
     community.general.lvg:
       vg: drbdpool
-      pvs: "{{ rdqm_storage_dev }}1"
-  when: "'drbdpool' not in vgsout.stdout_lines"
+      pvs: "/dev/{{ part_name }}"
+  when: "'drbdpool' not in ansible_facts.lvm.vgs.keys()|list"

--- a/resources/ansible/mq-automation/roles/mq-install/tasks/mq-install.yaml
+++ b/resources/ansible/mq-automation/roles/mq-install/tasks/mq-install.yaml
@@ -87,11 +87,12 @@
       owner: mqm
       group: mqm
       mode: '0644'
+    register: createdrdqm
   
   - name: Enable the local cluster
     shell: "/opt/mqm/bin/rdqmadm -c"
     register: clusterconfig
     failed_when: clusterconfig.rc != 0
-
-  when: "enable_rdqm == true"
+    when: createdrdqm.changed
+  when: "enable_rdqm|bool"
     


### PR DESCRIPTION
Adds the Queue Manager creation piece to the listed tasks. 
- By default these queue managers can be added to the group vars, but should also be able to be added from anything that can overwrite vars. 

Closes [#22](https://github.com/ibm-client-engineering/solution-mq-rdqm-hadr/issues/22)
